### PR TITLE
fix: adding weight classes

### DIFF
--- a/backend/api/models/utils/choices.py
+++ b/backend/api/models/utils/choices.py
@@ -2,6 +2,7 @@
 
 # 2018-Present
 
+__W40 = "W40"  # Youth only class
 __W45 = "W45"
 __W49 = "W49"
 __W55 = "W55"
@@ -14,20 +15,33 @@ __W87 = "W87"  # Senior/Junior only class
 __W81p = "W81+"  # Youth only class
 __W87p = "W87+"  # Senior/Junior only class
 
-CURRENT_FEMALE_WEIGHT_CATEGORIES = [
-    (__W45, "W45"),
-    (__W49, "W49"),
-    (__W55, "W55"),
-    (__W59, "W59"),
-    (__W64, "W64"),
-    (__W71, "W71"),
-    (__W76, "W76"),
-    (__W81, "W81"),
-    (__W87, "W87"),  # Senior/Junior only class
-    (__W81p, "W81+"),  # Youth only class
-    (__W87p, "W87+"),  # Senior/Junior only class
+CURRENT_YOUTH_ONLY_FEMALE_WEIGHT_CATEGORIES = [
+    (__W40, "W40"),
+    (__W81p, "W81+"),
 ]
 
+CURRENT_SENIOR_JUNIOR_ONLY_FEMALE_WEIGHT_CATEGORIES = [
+    (__W87, "W87"),
+    (__W87p, "W87+"),
+]
+
+
+CURRENT_FEMALE_WEIGHT_CATEGORIES = (
+    [
+        (__W45, "W45"),
+        (__W49, "W49"),
+        (__W55, "W55"),
+        (__W59, "W59"),
+        (__W64, "W64"),
+        (__W71, "W71"),
+        (__W76, "W76"),
+        (__W81, "W81"),
+    ]
+    + CURRENT_YOUTH_ONLY_FEMALE_WEIGHT_CATEGORIES
+    + CURRENT_SENIOR_JUNIOR_ONLY_FEMALE_WEIGHT_CATEGORIES
+)
+
+__M49 = "M49"  # Youth only class
 __M55 = "M55"
 __M61 = "M61"
 __M67 = "M67"
@@ -40,19 +54,32 @@ __M109 = "M109"  # Senior/Junior only class
 __M102p = "M102+"  # Youth only class
 __M109p = "M109+"  # Senior/Junior only class
 
-CURRENT_MALE_WEIGHT_CATEGORIES = [
-    (__M55, "M55"),
-    (__M61, "M61"),
-    (__M67, "M67"),
-    (__M73, "M73"),
-    (__M81, "M81"),
-    (__M89, "M89"),
-    (__M96, "M96"),
-    (__M102, "M102"),
-    (__M109, "M109"),  # Senior/Junior only class
+CURRENT_YOUTH_ONLY_MALE_WEIGHT_CATEGORIES = [
+    (__M49, "M49"),  # Youth only class
     (__M102p, "M102+"),  # Youth only class
+]
+
+CURRENT_SENIOR_JUNIOR_ONLY_MALE_WEIGHT_CATEGORIES = [
+    (__M109, "M109"),  # Senior/Junior only class
     (__M109p, "M109+"),  # Senior/Junior only class
 ]
+
+CURRENT_MALE_WEIGHT_CATEGORIES = (
+    [
+        (__M55, "M55"),
+        (__M61, "M61"),
+        (__M67, "M67"),
+        (__M73, "M73"),
+        (__M81, "M81"),
+        (__M89, "M89"),
+        (__M96, "M96"),
+        (__M102, "M102"),
+    ]
+    + CURRENT_YOUTH_ONLY_MALE_WEIGHT_CATEGORIES
+    + CURRENT_SENIOR_JUNIOR_ONLY_MALE_WEIGHT_CATEGORIES
+)
+
+# TODO: seperate Youth/Senior/Junior classes.
 
 # 1998-2018
 
@@ -62,9 +89,9 @@ __W58 = "W58"
 __W63 = "W63"
 __W69 = "W69"
 __W75 = "W75"
-__W75p = "W75+"
-__W90 = "W90"
-__W90p = "W90+"
+__W75p = "W75+"  # Youth
+__W90 = "W90"  # Senior/Junior
+__W90p = "W90+"  # Senior/Junior
 
 OLD_1998_2018_FEMALE_WEIGHT_CATEGORIES = [
     (__W48, "W48"),
@@ -78,22 +105,26 @@ OLD_1998_2018_FEMALE_WEIGHT_CATEGORIES = [
     (__W90p, "W90+"),
 ]
 
+__M50 = "M50"  # Youth
 __M56 = "M56"
 __M62 = "M62"
 __M69 = "M69"
 __M77 = "M77"
 __M85 = "M85"
 __M94 = "M94"
-__M105 = "M105"
-__M105p = "M105+"
+__M94p = "M94+"  # Youth
+__M105 = "M105"  # Senior
+__M105p = "M105+"  # Senior
 
 OLD_1998_2018_MALE_WEIGHT_CATEGORIES = [
+    (__M50, "M50"),
     (__M56, "M56"),
     (__M62, "M62"),
     (__M69, "M69"),
     (__M77, "M77"),
     (__M85, "M85"),
     (__M94, "M94"),
+    (__M94p, "M94+"),
     (__M105, "M105"),
     (__M105p, "M105+"),
 ]


### PR DESCRIPTION
Relating to: #18 

> Categories that need adding:
> 
> Current:
> 
>     Youth Male 49
>     Youth Female 40
> 
> Legacy:
> 
>     Male 56, 69
>     Female 58
>     Youth Male 50, 94, 94+
>     Youth Female 44, 69, 69+
From: https://github.com/WeightliftingNZ/lifter-api/issues/18#issuecomment-1246090195

Added current Youth Categories - apologies for missing them!

Seems:
Male 56, 69, Female 58 already exited.

Added the youth categories as well for legacy.

What has not been added is validation - so careful with this. That means you can put a senior lifter into a Youth category on the API, so this will need to be handled before adding lifts to the DB.

I want to make this PR, so it won't limit you @ditorelo from adding new data.

I will make another issue to remind me about adding validation.